### PR TITLE
Fix mangled HTML card templating

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -12,7 +12,7 @@ All parameters are optional.
 
 {% endcomment %}
 
-`<figure class="card">
+<figure class="card">
 	{% if include.url %}
   <a href="{{ include.url }}">
 	{% endif %}
@@ -28,4 +28,4 @@ All parameters are optional.
 	{% endif %}
 	</figcaption>
 	{% if include.url %}</a>{% endif %}
-</figure>`{=html}
+</figure>


### PR DESCRIPTION
I haven't actually tested whether this fixes the problem below but I suspect it will:

![image](https://github.com/user-attachments/assets/3fb31e5d-c4d1-49f7-953a-79b6cfcfba80)
